### PR TITLE
Multicast system

### DIFF
--- a/common/src/main/kotlin/com/github/picture2pc/common/net/multicast/MulticastTransceiver.kt
+++ b/common/src/main/kotlin/com/github/picture2pc/common/net/multicast/MulticastTransceiver.kt
@@ -22,7 +22,7 @@ class MulticastTransceiver {
     private val subscriptions = mutableListOf<Pair<Payload, PayloadRecievedCallback>>()
     private var awationLoopActive = false
 
-    fun sendMessage(payload: Payload) {
+    fun sendPayload(payload: Payload) {
         socket.sendMessage(payload.content)
     }
 

--- a/common/src/main/kotlin/com/github/picture2pc/common/net/multicast/MulticastTransceiver.kt
+++ b/common/src/main/kotlin/com/github/picture2pc/common/net/multicast/MulticastTransceiver.kt
@@ -1,0 +1,56 @@
+package com.github.picture2pc.common.net.multicast
+
+private typealias PayloadRecievedCallback = () -> Unit
+
+class MulticastTransceiver {
+    companion object {
+        private const val multicastAddress = "232.242.119.180"
+        private const val multicastPort = 42852
+
+        enum class Payload(val content: String) {
+            SERVER_ONLINE("<P2PC|SERVER-ONLINE>"),
+            LIST_SERVERS("<P2PC|LIST-SERVERS>");
+
+            companion object {
+                fun fromContent(content: String) = values().find { it.content == content }
+            }
+        }
+
+    }
+
+    private val socket = SimpleMulticastSocket(multicastAddress, multicastPort)
+    private val subscriptions = mutableListOf<Pair<Payload, PayloadRecievedCallback>>()
+    private var awationLoopActive = false
+
+    fun sendMessage(payload: Payload) {
+        socket.sendMessage(payload.content)
+    }
+
+    fun subscribeToPayload(payload: Payload, callback: PayloadRecievedCallback) {
+        subscriptions += payload to callback
+    }
+
+    fun awaitNextMessage(timeoutMs: Int? = null): Payload? {
+        val message = socket.readMessage(timeoutMs) ?: return null
+        val payload = Payload.fromContent(message) ?: return null
+
+        payload.invokeMatchingCallbacks()
+        return payload
+    }
+
+    fun runAwationLoop() {
+        awationLoopActive = true
+        while (awationLoopActive) awaitNextMessage(50)
+    }
+
+    fun stopAwationLoop() {
+        awationLoopActive = false
+    }
+
+    private fun Payload.invokeMatchingCallbacks() = subscriptions
+        .filter { it.first == this }
+        .map { it.second }
+        .forEach { it.invoke() }
+
+}
+

--- a/common/src/main/kotlin/com/github/picture2pc/common/net/multicast/SimpleMulticastSocket.kt
+++ b/common/src/main/kotlin/com/github/picture2pc/common/net/multicast/SimpleMulticastSocket.kt
@@ -1,0 +1,46 @@
+package com.github.picture2pc.common.net.multicast
+
+import java.net.DatagramPacket
+import java.net.InetSocketAddress
+import java.net.NetworkInterface
+import java.net.SocketTimeoutException
+
+
+internal class SimpleMulticastSocket(
+    address: String,
+    port: Int,
+    private val recieveBufferSize: Int = 1024
+) {
+    private val socketAddress = InetSocketAddress(address, port)
+    private val jvmMulticastSocket = java.net.MulticastSocket(port)
+
+    init {
+        val networkInterface = NetworkInterface.getByInetAddress(socketAddress.address)
+        jvmMulticastSocket.joinGroup(socketAddress, networkInterface)
+    }
+
+    fun sendMessage(message: String) {
+        val buffer = message.encodeToByteArray()
+        val packet = DatagramPacket(buffer, buffer.size, socketAddress)
+        jvmMulticastSocket.send(packet)
+    }
+
+    fun readMessage(timeoutMs: Int? = null): String? {
+        jvmMulticastSocket.soTimeout = (timeoutMs ?: 0).coerceAtLeast(0)
+
+        val buffer = ByteArray(recieveBufferSize)
+        val packet = DatagramPacket(buffer, buffer.size)
+
+        try {
+            jvmMulticastSocket.receive(packet)
+        }
+        catch (e: SocketTimeoutException) {
+            return null
+        }
+
+        return buffer.decodeToString().removeNullBytes()
+    }
+
+    private fun String.removeNullBytes() = replace("\u0000", "")
+
+}


### PR DESCRIPTION
Indroduces a `MulticastTransceiver` class to simplify multicast messaging. `MulticastTransciever` uses `SimpleMulticastSocket`, a simplification of the builtin JVM `MulticastSocket` class, to send and recieve multicast messages.

Code example:
```kotlin
val multicastTransceiver = MulticastTransceiver()

multicastTransceiver.subscribeToPayload(MulticastTransceiver.Companion.Payload.LIST_SERVERS) {
    multicastTransceiver.sendPayload(MulticastTransceiver.Companion.Payload.SERVER_ONLINE)
}

multicastTransceiver.runAwationLoop()
```
