### PR TITLE
Improve multicast system to support variable payload contents and access to the sender address

### DIFF
--- a/common/src/main/kotlin/com/github/picture2pc/common/net/multicast/MulticastPayloads.kt
+++ b/common/src/main/kotlin/com/github/picture2pc/common/net/multicast/MulticastPayloads.kt
@@ -1,0 +1,41 @@
+package com.github.picture2pc.common.net.multicast
+
+
+sealed interface MulticastPayload {
+    val stringRepresentation: String
+}
+
+object MulticastPayloads {
+    object ListServers : MulticastPayload {
+        internal val regex = "<P2PC\\|LIST-SERVERS>".toRegex()
+
+        override val stringRepresentation = "<P2PC|LIST-SERVERS>"
+    }
+
+    class ServerOnline(val deviceName: String) : MulticastPayload {
+        internal companion object {
+            internal val regex = "<P2PC\\|SERVER-ONLINE\\|NAME:(?<deviceName>.+)>".toRegex()
+
+            internal fun fromString(string: String): ServerOnline {
+                val groups = regex.matchEntire(string)!!.groups
+
+                val deviceName = groups["deviceName"]!!.value
+
+                return ServerOnline(deviceName)
+            }
+        }
+
+        override val stringRepresentation = "<P2PC|SERVER-ONLINE|NAME:$deviceName>"
+    }
+
+    private val regexToPayloadFactoryFunctions: Map<Regex, (String) -> MulticastPayload> = mapOf(
+        ListServers.regex to { ListServers },
+        ServerOnline.regex to ServerOnline::fromString
+    )
+
+    internal fun createPayloadFromString(string: String) = regexToPayloadFactoryFunctions
+        .filterKeys { it.matches(string) }
+        .values
+        .firstOrNull()
+        ?.invoke(string)
+}

--- a/common/src/main/kotlin/com/github/picture2pc/common/net/multicast/ReceivedMulticastPacket.kt
+++ b/common/src/main/kotlin/com/github/picture2pc/common/net/multicast/ReceivedMulticastPacket.kt
@@ -1,0 +1,3 @@
+package com.github.picture2pc.common.net.multicast
+
+data class ReceivedMulticastPacket(val content: String, val address: String)

--- a/common/src/main/kotlin/com/github/picture2pc/common/net/multicast/SimpleMulticastSocket.kt
+++ b/common/src/main/kotlin/com/github/picture2pc/common/net/multicast/SimpleMulticastSocket.kt
@@ -25,7 +25,7 @@ internal class SimpleMulticastSocket(
         jvmMulticastSocket.send(packet)
     }
 
-    fun readMessage(timeoutMs: Int? = null): String? {
+    fun recievePacket(timeoutMs: Int? = null): ReceivedMulticastPacket? {
         jvmMulticastSocket.soTimeout = (timeoutMs ?: 0).coerceAtLeast(0)
 
         val buffer = ByteArray(recieveBufferSize)
@@ -38,7 +38,10 @@ internal class SimpleMulticastSocket(
             return null
         }
 
-        return buffer.decodeToString().removeNullBytes()
+        val content = buffer.decodeToString().removeNullBytes()
+        val address = packet.address.hostAddress
+
+        return ReceivedMulticastPacket(content, address)
     }
 
     private fun String.removeNullBytes() = replace("\u0000", "")


### PR DESCRIPTION
Prevoiusly the multicast system was limited to sending and receiving only fixed content payloads. This rewrite adds support for variable payloads to include additional data in the payload (device names for example).

Code example:
```kt
val multicastTransceiver = MulticastTransceiver()

multicastTransceiver.subscribeToPayload { payload: MulticastPayloads.ServerOnline, packet: ReceivedMulticastPacket ->
    println("Received ServerOnline from device with name ${payload.deviceName} and address ${packet.address}")
}

multicastTransceiver.runAwationLoop()
```