### PR TITLE
Fix/android/85 detected points do not match image corners

### DIFF
--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -14,6 +14,7 @@ repositories {
 dependencies {
     implementation(libs.koin.android)
     implementation(libs.core.ktx)
+    implementation(libs.exifinterface)
 
     val composeBom = platform("androidx.compose:compose-bom:2023.04.01")
     implementation(composeBom)

--- a/android/src/main/kotlin/com/github/picture2pc/android/data/edgedetection/EdgeDetect.kt
+++ b/android/src/main/kotlin/com/github/picture2pc/android/data/edgedetection/EdgeDetect.kt
@@ -7,7 +7,7 @@ import org.opencv.core.Point
 import org.opencv.core.Rect
 
 interface EdgeDetect {
-    fun load(context: Context)
+    suspend fun load(context: Context)
     fun detect(bit: Bitmap): List<DetectedBox>
 }
 

--- a/android/src/main/kotlin/com/github/picture2pc/android/data/edgedetection/impl/YOLOv8SegEdgeDetect.kt
+++ b/android/src/main/kotlin/com/github/picture2pc/android/data/edgedetection/impl/YOLOv8SegEdgeDetect.kt
@@ -5,6 +5,9 @@ import android.graphics.Bitmap
 import com.github.picture2pc.android.R
 import com.github.picture2pc.android.data.edgedetection.DetectedBox
 import com.github.picture2pc.android.data.edgedetection.EdgeDetect
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import org.opencv.android.Utils
 import org.opencv.core.Core
 import org.opencv.core.CvType
@@ -28,19 +31,21 @@ import kotlin.math.max
 import kotlin.math.min
 import kotlin.math.roundToInt
 
-class YOLOv8SegEdgeDetect : EdgeDetect {
+class YOLOv8SegEdgeDetect(private val ioDispatcher: CoroutineDispatcher) : EdgeDetect {
     private lateinit var documentModel: Net
 
-    private fun loadModel(context: Context): Net {
+    private suspend fun loadModel(context: Context): Net {
         val inputStream = context.resources.openRawResource(R.raw.documentdetect)
-        val buffer = ByteArray(inputStream.available())
-        inputStream.read(buffer)
-        inputStream.close()
-
+        val buffer : ByteArray
+        withContext(ioDispatcher) {
+            buffer = ByteArray(inputStream.available())
+            inputStream.read(buffer)
+            inputStream.close()
+        }
         return Dnn.readNetFromONNX(MatOfByte(*buffer))
     }
 
-    override fun load(context: Context) {
+    override suspend fun load(context: Context) {
         documentModel = loadModel(context)
     }
 

--- a/android/src/main/kotlin/com/github/picture2pc/android/data/takeimage/PictureManager.kt
+++ b/android/src/main/kotlin/com/github/picture2pc/android/data/takeimage/PictureManager.kt
@@ -3,11 +3,12 @@ package com.github.picture2pc.android.data.takeimage
 import android.graphics.Bitmap
 import androidx.camera.view.PreviewView
 import com.github.picture2pc.android.data.edgedetection.DetectedBox
+import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 
 interface PictureManager {
-    val takenImages: SharedFlow<Bitmap>
+    val takenImages: SharedFlow<Pair<Bitmap, Deferred<DetectedBox?>>>
     val pictureCorners: StateFlow<DetectedBox?>
 
     fun switchFlashMode()

--- a/android/src/main/kotlin/com/github/picture2pc/android/data/takeimage/impl/CameraPictureManager.kt
+++ b/android/src/main/kotlin/com/github/picture2pc/android/data/takeimage/impl/CameraPictureManager.kt
@@ -4,7 +4,6 @@ import android.content.Context
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import android.graphics.Matrix
-import android.media.ExifInterface
 import android.util.Log
 import androidx.camera.core.CameraSelector
 import androidx.camera.core.ImageAnalysis
@@ -15,8 +14,8 @@ import androidx.camera.core.Preview
 import androidx.camera.lifecycle.ProcessCameraProvider
 import androidx.camera.view.PreviewView
 import androidx.core.content.ContextCompat
+import androidx.exifinterface.media.ExifInterface
 import androidx.lifecycle.LifecycleOwner
-import androidx.lifecycle.lifecycleScope
 import com.github.picture2pc.android.data.edgedetection.DetectedBox
 import com.github.picture2pc.android.data.edgedetection.EdgeDetect
 import com.github.picture2pc.android.data.takeimage.PictureManager
@@ -24,6 +23,7 @@ import com.google.common.util.concurrent.ListenableFuture
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -32,9 +32,9 @@ import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.future.asCompletableFuture
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
 import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
 import java.io.File
@@ -46,6 +46,7 @@ class CameraPictureManager(
     private val context: Context,
     private val edgeDetect: EdgeDetect,
     private val coroutineScope: CoroutineScope,
+    defaultDispatcher: CoroutineDispatcher,
     private val imageCapture: ImageCapture = ImageCapture.Builder()
         .setFlashMode(ImageCapture.FLASH_MODE_OFF)
         .setCaptureMode(ImageCapture.CAPTURE_MODE_MINIMIZE_LATENCY)
@@ -57,8 +58,10 @@ class CameraPictureManager(
     private val lifecycleOwner: LifecycleOwner = context as LifecycleOwner
     private val _pictureCorners: MutableStateFlow<DetectedBox?> =
         MutableStateFlow(null) //read and write
-    override val pictureCorners: StateFlow<DetectedBox?> = _pictureCorners.asStateFlow()
 
+    @OptIn(ExperimentalCoroutinesApi::class)
+    private val singleThreadContext = defaultDispatcher.limitedParallelism(1)
+    override val pictureCorners: StateFlow<DetectedBox?> = _pictureCorners.asStateFlow()
 
     override fun switchFlashMode() {
         if (imageCapture.flashMode == FLASH_MODE_AUTO) {
@@ -108,10 +111,15 @@ class CameraPictureManager(
                 .setBackpressureStrategy(ImageAnalysis.STRATEGY_KEEP_ONLY_LATEST)
                 .build()
             analyzerUseCase.setAnalyzer(ContextCompat.getMainExecutor(context)) { image ->
-                val res = runDetection(image.toBitmap())
-                if (res != null)
-                    _pictureCorners.value = res
-                image.close()
+                if (singleThreadContext[Job]?.isCompleted != false)
+                    coroutineScope.launch {
+                        val res = runDetection(image.toBitmap())
+                        if (res != null)
+                            _pictureCorners.value = res
+                        image.close()
+                    }
+                else
+                    image.close()
             }
             runBlocking { edgeDetect.load(context) }
 
@@ -140,8 +148,11 @@ class CameraPictureManager(
         }
     }
 
-    private fun runDetection(image: Bitmap): DetectedBox? {
-        return edgeDetect.detect(image).filter { it.points.size >= 4 }.minByOrNull { it.points.size }
+    private suspend fun runDetection(image: Bitmap): DetectedBox? {
+        return withContext(singleThreadContext) { // TODO: move single thread stuff to EdgeDetect.kt
+            return@withContext edgeDetect.detect(image).filter { it.points.size >= 4 }
+                .minByOrNull { it.points.size }
+        }
     }
 
     fun rotateImageIfRequired(image: Bitmap, imageData: ByteArray): Bitmap {

--- a/android/src/main/kotlin/com/github/picture2pc/android/data/takeimage/impl/CameraPictureManager.kt
+++ b/android/src/main/kotlin/com/github/picture2pc/android/data/takeimage/impl/CameraPictureManager.kt
@@ -21,13 +21,20 @@ import com.github.picture2pc.android.data.edgedetection.DetectedBox
 import com.github.picture2pc.android.data.edgedetection.EdgeDetect
 import com.github.picture2pc.android.data.takeimage.PictureManager
 import com.google.common.util.concurrent.ListenableFuture
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.future.asCompletableFuture
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
 import java.io.File
@@ -38,6 +45,7 @@ import java.io.IOException
 class CameraPictureManager(
     private val context: Context,
     private val edgeDetect: EdgeDetect,
+    private val coroutineScope: CoroutineScope,
     private val imageCapture: ImageCapture = ImageCapture.Builder()
         .setFlashMode(ImageCapture.FLASH_MODE_OFF)
         .setCaptureMode(ImageCapture.CAPTURE_MODE_MINIMIZE_LATENCY)
@@ -76,8 +84,13 @@ class CameraPictureManager(
                     val image =
                         BitmapFactory.decodeByteArray(imageData, 0, imageData.size)
                     val rotatedImage = rotateImageIfRequired(image, imageData)
-                    lifecycleOwner.lifecycleScope.launch {
-                        _takenImages.emit(rotatedImage)
+                    coroutineScope.launch {
+                        val cJob = coroutineScope.async {
+                            val res = runDetection(rotatedImage)
+                            return@async res
+                        }
+                        cJob.start()
+                        _takenImages.emit(Pair(rotatedImage, cJob))
                     }
                 }
             }
@@ -90,18 +103,18 @@ class CameraPictureManager(
             val preview = Preview.Builder().build().also {
                 it.surfaceProvider = previewView.surfaceProvider
             }
-
             val analyzerUseCase = ImageAnalysis.Builder()
                 .setOutputImageRotationEnabled(true)
                 .setBackpressureStrategy(ImageAnalysis.STRATEGY_KEEP_ONLY_LATEST)
                 .build()
             analyzerUseCase.setAnalyzer(ContextCompat.getMainExecutor(context)) { image ->
-                val res = edgeDetect.detect(image.toBitmap()).filter { it.points.size >= 4 }.minByOrNull { it.points.size }
+                val res = runDetection(image.toBitmap())
                 if (res != null)
                     _pictureCorners.value = res
                 image.close()
             }
-            edgeDetect.load(context)
+            runBlocking { edgeDetect.load(context) }
+
             cameraProvider.unbindAll()
             cameraProvider.bindToLifecycle(
                 lifecycleOwner,
@@ -114,7 +127,7 @@ class CameraPictureManager(
     }
 
     override fun saveImageToCache() {
-        val image = takenImages.replayCache.lastOrNull() ?: return
+        val image = takenImages.replayCache.lastOrNull()?.first ?: return
 
         val fileUri = File.createTempFile("img.png", ".png", context.externalCacheDir)
         try {
@@ -125,6 +138,10 @@ class CameraPictureManager(
         } catch (e: IOException) {
             Log.e("CameraImageManager", "Error saving image to cache", e)
         }
+    }
+
+    private fun runDetection(image: Bitmap): DetectedBox? {
+        return edgeDetect.detect(image).filter { it.points.size >= 4 }.minByOrNull { it.points.size }
     }
 
     fun rotateImageIfRequired(image: Bitmap, imageData: ByteArray): Bitmap {
@@ -148,7 +165,7 @@ class CameraPictureManager(
     }
 
     private val _takenImages =
-        MutableSharedFlow<Bitmap>(replay = 3)            //read and write
-    override val takenImages: SharedFlow<Bitmap> =
+        MutableSharedFlow<Pair<Bitmap, Deferred<DetectedBox?>>>(replay = 3)            //read and write
+    override val takenImages: SharedFlow<Pair<Bitmap, Deferred<DetectedBox?>>> =
         _takenImages.asSharedFlow()  //read only
 }

--- a/android/src/main/kotlin/com/github/picture2pc/android/di/Modules.kt
+++ b/android/src/main/kotlin/com/github/picture2pc/android/di/Modules.kt
@@ -40,9 +40,9 @@ val appModule = module {
 
 
     single { BroadcastViewModel(get()) }
-    single<EdgeDetect> { YOLOv8SegEdgeDetect() }
+    single<EdgeDetect> { YOLOv8SegEdgeDetect(get(named("ioDispatcher"))) }
     single { ClientsViewModel(get()) }
-    single<PictureManager> { CameraPictureManager(get(), get()) }
+    single<PictureManager> { CameraPictureManager(get(), get(), get(named("backgroundCoroutineScope"))) }
     single { CameraViewModel(get(), get()) }
     single { ScreenSelectorViewModel() }
 

--- a/android/src/main/kotlin/com/github/picture2pc/android/di/Modules.kt
+++ b/android/src/main/kotlin/com/github/picture2pc/android/di/Modules.kt
@@ -14,15 +14,18 @@ import com.github.picture2pc.android.viewmodel.mainscreenviewmodels.BroadcastVie
 import com.github.picture2pc.android.viewmodel.mainscreenviewmodels.ClientsViewModel
 import com.github.picture2pc.android.viewmodel.screenselectorviewmodels.ScreenSelectorViewModel
 import com.github.picture2pc.common.di.commonAppModule
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
 import org.koin.core.qualifier.named
 import org.koin.dsl.module
 
 val appModule = module {
     includes(commonAppModule)
 
-    single(named("backgroundCoroutineScope")) { CoroutineScope(Dispatchers.Default) }
+    single(named("defaultDispatcher")) { Dispatchers.Default }
+    single(named("backgroundCoroutineScope")) { CoroutineScope(get<CoroutineDispatcher>(named("defaultDispatcher")) + SupervisorJob()) }
     single<DataTransmitter> {
         MulticastTcpDataTransmitter(
             get(),
@@ -42,7 +45,14 @@ val appModule = module {
     single { BroadcastViewModel(get()) }
     single<EdgeDetect> { YOLOv8SegEdgeDetect(get(named("ioDispatcher"))) }
     single { ClientsViewModel(get()) }
-    single<PictureManager> { CameraPictureManager(get(), get(), get(named("backgroundCoroutineScope"))) }
+    single<PictureManager> {
+        CameraPictureManager(
+            get(),
+            get(),
+            get(named("backgroundCoroutineScope")),
+            get(named("defaultDispatcher"))
+        )
+    }
     single { CameraViewModel(get(), get()) }
     single { ScreenSelectorViewModel() }
 

--- a/android/src/main/kotlin/com/github/picture2pc/android/ui/main/bigpicturescreen/HorizontalBigPictureScreen.kt
+++ b/android/src/main/kotlin/com/github/picture2pc/android/ui/main/bigpicturescreen/HorizontalBigPictureScreen.kt
@@ -29,7 +29,7 @@ fun HorizontalBigPictureScreen(
     cameraViewModel: CameraViewModel = rememberKoinInject(),
     screenSelectorViewModel: ScreenSelectorViewModel = rememberKoinInject()
 ) {
-    val image = cameraViewModel.takenImage.collectAsState(initial = null).value
+    val image = cameraViewModel.takenImage.collectAsState().value?.first
 
     Box(
         modifier = Modifier

--- a/android/src/main/kotlin/com/github/picture2pc/android/ui/main/bigpicturescreen/VerticalBigPictureScreen.kt
+++ b/android/src/main/kotlin/com/github/picture2pc/android/ui/main/bigpicturescreen/VerticalBigPictureScreen.kt
@@ -31,7 +31,7 @@ fun VerticalBigPictureScreen(
     cameraViewModel: CameraViewModel = rememberKoinInject(),
     screenSelectorViewModel: ScreenSelectorViewModel = rememberKoinInject()
 ) {
-    val image = cameraViewModel.takenImage.collectAsState(initial = null).value
+    val image = cameraViewModel.takenImage.collectAsState().value?.first
 
     Box(
         modifier = Modifier

--- a/android/src/main/kotlin/com/github/picture2pc/android/ui/main/camerascreen/HorizontalCameraScreen.kt
+++ b/android/src/main/kotlin/com/github/picture2pc/android/ui/main/camerascreen/HorizontalCameraScreen.kt
@@ -27,7 +27,7 @@ fun HorizontalCameraScreen(
     cameraViewModel: CameraViewModel = rememberKoinInject(),
     screenSelectorViewModel: ScreenSelectorViewModel = rememberKoinInject()
 ) {
-    val image = cameraViewModel.takenImage.collectAsState(initial = null).value
+    val image = cameraViewModel.takenImage.collectAsState().value?.first
 
     Box(
         Modifier

--- a/android/src/main/kotlin/com/github/picture2pc/android/ui/main/camerascreen/VerticalCameraScreen.kt
+++ b/android/src/main/kotlin/com/github/picture2pc/android/ui/main/camerascreen/VerticalCameraScreen.kt
@@ -30,7 +30,7 @@ fun VerticalCameraScreen(
     cameraViewModel: CameraViewModel = rememberKoinInject(),
     screenSelectorViewModel: ScreenSelectorViewModel = rememberKoinInject()
 ) {
-    val image = cameraViewModel.takenImage.collectAsState(initial = null).value
+    val image = cameraViewModel.takenImage.collectAsState().value?.first
 
     Box(
         modifier = Modifier

--- a/android/src/main/kotlin/com/github/picture2pc/android/viewmodel/camerascreenviewmodels/CameraViewModel.kt
+++ b/android/src/main/kotlin/com/github/picture2pc/android/viewmodel/camerascreenviewmodels/CameraViewModel.kt
@@ -1,6 +1,5 @@
 package com.github.picture2pc.android.viewmodel.camerascreenviewmodels
 
-import android.graphics.Bitmap
 import androidx.camera.view.PreviewView
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
@@ -12,12 +11,9 @@ import com.github.picture2pc.android.ui.util.FlashStates
 import com.github.picture2pc.android.ui.util.next
 import com.github.picture2pc.common.net.data.payload.TcpPayload
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.shareIn
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 
@@ -48,10 +44,17 @@ class CameraViewModel(
         if (takenImage.value == null)
             return
         viewModelScope.launch {
+            val points = takenImage.value!!.second.await()?.pointsBox?.map {
+                Pair(
+                    it.x.toFloat(),
+                    it.y.toFloat()
+                )
+            }
+            println(points)
             dataTransmitter.sendPicture(
                 TcpPayload.Picture(
                     takenImage.value!!.first.toByteArray(),
-                    takenImage.value!!.second.await()?.pointsBox?.map { Pair(it.x.toFloat(), it.y.toFloat()) }
+                    points
                 )
             )
         }

--- a/android/src/main/kotlin/com/github/picture2pc/android/viewmodel/camerascreenviewmodels/CameraViewModel.kt
+++ b/android/src/main/kotlin/com/github/picture2pc/android/viewmodel/camerascreenviewmodels/CameraViewModel.kt
@@ -13,49 +13,45 @@ import com.github.picture2pc.android.ui.util.next
 import com.github.picture2pc.common.net.data.payload.TcpPayload
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.shareIn
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 
 class CameraViewModel(
     private val pictureManager: PictureManager,
     private val dataTransmitter: DataTransmitter
 ) : ViewModel() {
-    val takenImage: SharedFlow<Bitmap>
-        get() {
-            return pictureManager.takenImages
-        }
+    val takenImage = pictureManager.takenImages.stateIn(viewModelScope, SharingStarted.Eagerly, null)
+
 
     private val _flashMode: MutableStateFlow<FlashStates> = MutableStateFlow(FlashStates.FLASH_OFF)
     val flashMode: StateFlow<FlashStates> get() = _flashMode.asStateFlow()
-
-    private var lastCorners: List<Pair<Float, Float>>? = null
 
     val pictureCorners: StateFlow<DetectedBox?>
         get() {
             return pictureManager.pictureCorners
         }
 
-    fun getLastImage(): Bitmap {
-        return pictureManager.takenImages.replayCache.last()
-    }
-
     fun setViewFinder(previewView: PreviewView) {
         pictureManager.setViewFinder(previewView)
     }
 
     fun takeImage() {
-        lastCorners =
-            pictureCorners.value?.pointsBox?.map { Pair(it.x.toFloat(), it.y.toFloat()) }
         pictureManager.takeImage()
     }
 
     fun sendImage() {
+        if (takenImage.value == null)
+            return
         viewModelScope.launch {
             dataTransmitter.sendPicture(
                 TcpPayload.Picture(
-                    getLastImage().toByteArray(),
-                    lastCorners
+                    takenImage.value!!.first.toByteArray(),
+                    takenImage.value!!.second.await()?.pointsBox?.map { Pair(it.x.toFloat(), it.y.toFloat()) }
                 )
             )
         }

--- a/desktop/src/main/kotlin/com/github/picture2pc/desktop/ui/main/MainScreen.kt
+++ b/desktop/src/main/kotlin/com/github/picture2pc/desktop/ui/main/MainScreen.kt
@@ -3,6 +3,7 @@ package com.github.picture2pc.desktop.ui.main
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight

--- a/desktop/src/main/kotlin/com/github/picture2pc/desktop/ui/main/elements/ImageInteraction.kt
+++ b/desktop/src/main/kotlin/com/github/picture2pc/desktop/ui/main/elements/ImageInteraction.kt
@@ -50,7 +50,6 @@ fun ImageInteractionButtons(
                 buttonModifier = Modifier.width(75.dp)
             ) {
                 pDVM.reset()
-                mDVM.clear()
             }
             Spacer(spacerSize)
 

--- a/desktop/src/main/kotlin/com/github/picture2pc/desktop/ui/main/elements/PictureDisplay.kt
+++ b/desktop/src/main/kotlin/com/github/picture2pc/desktop/ui/main/elements/PictureDisplay.kt
@@ -51,7 +51,11 @@ fun Picture(
             bitmap = pictureBitmap.asComposeImageBitmap(),
             contentDescription = "Picture",
             modifier = Modifier
-                .onGloballyPositioned { imageSize.value = it.size.toSize() }
+                .onGloballyPositioned {
+                    imageSize.value = it.size.toSize(); pDVM.calculateRatio(
+                    imageSize.value
+                )
+                }
                 .pointerInput(Unit) {
                     detectTapGestures { offset ->
                         mHVM.addClick(offset.normalize(imageSize.value))
@@ -81,9 +85,7 @@ fun Picture(
         Canvas(Modifier) {
             val scale = canvasSize.value.minDimension
 
-            clicks.forEach {
-                drawCircle(Colors.PRIMARY, 5f, it.denormalize(canvasSize.value))
-            }
+            // Draw box around corners
             val selectedClicks =
                 if (clicks.size == 3 && dragPoint != null && mHVM.prevEnabled) mHVM.sortClicks(
                     clicks + dragPoint
@@ -113,48 +115,52 @@ fun Picture(
             }
 
             // Part that is responsible for hover zoomed in preview
-            if (dragPoint == null) return@Canvas
-            val absoluteDragPoint = dragPoint.denormalize(canvasSize.value)
-            translate(
-                absoluteDragPoint.x,
-                absoluteDragPoint.y
-            ) {
-                clipPath(Path().apply {
-                    addOval(
-                        Rect(
-                            Offset(
-                                Settings.ZOOM_DIAMETER,
-                                Settings.ZOOM_DIAMETER
-                            ) * -scale,
-                            Size(
-                                Settings.ZOOM_DIAMETER * scale * 2,
-                                Settings.ZOOM_DIAMETER * scale * 2
+            if (dragPoint != null) {
+                val absoluteDragPoint = dragPoint.denormalize(canvasSize.value)
+                translate(
+                    absoluteDragPoint.x,
+                    absoluteDragPoint.y
+                ) {
+                    clipPath(Path().apply {
+                        addOval(
+                            Rect(
+                                Offset(
+                                    Settings.ZOOM_DIAMETER,
+                                    Settings.ZOOM_DIAMETER
+                                ) * -scale,
+                                Size(
+                                    Settings.ZOOM_DIAMETER * scale * 2,
+                                    Settings.ZOOM_DIAMETER * scale * 2
+                                )
                             )
                         )
-                    )
-                }) {
-                    translate(
-                        -absoluteDragPoint.x * Settings.ZOOM_FACTOR,
-                        -absoluteDragPoint.y * Settings.ZOOM_FACTOR
-                    ) {
-                        pDVM.calculateRatio(imageSize.value)
-                        scale(Settings.ZOOM_FACTOR / pDVM.getRatio()) { // Scaled picture
-                            drawImage(
-                                pictureBitmap.asComposeImageBitmap()
-                            )
+                    }) {
+                        translate(
+                            -absoluteDragPoint.x * Settings.ZOOM_FACTOR,
+                            -absoluteDragPoint.y * Settings.ZOOM_FACTOR
+                        ) {
+                            scale(Settings.ZOOM_FACTOR / pDVM.getRatio()) { // Scaled picture
+                                drawImage(
+                                    pictureBitmap.asComposeImageBitmap()
+                                )
+                            }
                         }
                     }
+                    drawCircle( //inner circle
+                        Colors.PRIMARY,
+                        Settings.ZOOM_DIAMETER * 0.1f * scale,
+                        style = Stroke(width = 2f)
+                    )
+                    drawCircle( //outer circle
+                        Colors.PRIMARY,
+                        Settings.ZOOM_DIAMETER * scale,
+                        style = Stroke(width = 2f)
+                    )
                 }
-                drawCircle( //inner circle
-                    Colors.PRIMARY,
-                    Settings.ZOOM_DIAMETER * 0.1f * scale,
-                    style = Stroke(width = 2f)
-                )
-                drawCircle( //outer circle
-                    Colors.PRIMARY,
-                    Settings.ZOOM_DIAMETER * scale,
-                    style = Stroke(width = 2f)
-                )
+            }
+            // Draw 4 corner dots
+            clicks.forEach {
+                drawCircle(Colors.PRIMARY, 0.01f * scale, it.denormalize(canvasSize.value))
             }
         }
     }

--- a/desktop/src/main/kotlin/com/github/picture2pc/desktop/viewmodel/mainscreen/MovementHandlerViewModel.kt
+++ b/desktop/src/main/kotlin/com/github/picture2pc/desktop/viewmodel/mainscreen/MovementHandlerViewModel.kt
@@ -43,7 +43,13 @@ class MovementHandlerViewModel {
      */
     fun addClick(click: Offset) {
         val clickC = clampOffset(click)
-        if (clicks.value.size == CLICK_COUNT) clearClicks()
+        if (clicks.value.size == CLICK_COUNT) {
+            val (closestPoint, distance) = getClosestPoint(click) // if  circle made in rage of other replace other
+            if (distance < BUTTON_CHOOSE_HITRADIUS)
+                removeClick(closestPoint)
+            else
+                clearClicks()
+        }
         _clicks.value = sortClicks(clicks.value + clickC) // Set clicks to sort clicks
     }
 
@@ -110,17 +116,17 @@ class MovementHandlerViewModel {
         clearClicks()
     }
 
-    fun setClicks(clicks: List<Offset>) {
-        _clicks.value = clicks.map {
+    fun setClicks(newClicks: List<Offset>) {
+        _clicks.value = newClicks.map {
             clampOffset(it)
         }
     }
 
     fun rotate(clockwise: Boolean) {
         rotationState.value = rotationState.value.next(clockwise)
-        _clicks.value = _clicks.value.map {
+        _clicks.value = sortClicks(_clicks.value.map {
             it.toCenteredOrigin(Size(1f, 1f)).translate(clockwise).toTopLeftOrigin(Size(1f, 1f))
-        }
+        })
     }
 
     fun updateDraggingSpeed() {
@@ -129,6 +135,6 @@ class MovementHandlerViewModel {
 
     companion object {
         const val CLICK_COUNT = 4
-        const val BUTTON_CHOOSE_HITRADIUS = 0.01
+        const val BUTTON_CHOOSE_HITRADIUS = 0.013
     }
 }

--- a/desktop/src/main/kotlin/com/github/picture2pc/desktop/viewmodel/mainscreen/PictureDisplayViewModel.kt
+++ b/desktop/src/main/kotlin/com/github/picture2pc/desktop/viewmodel/mainscreen/PictureDisplayViewModel.kt
@@ -57,9 +57,9 @@ class PictureDisplayViewModel(
         pP.setOriginalPicture(
             payload.picture.toImage().toComposeImageBitmap().asSkiaBitmap()
         )
+        pP.calculateRatio(displayPictureSize)
         if (payload.corners == null) return
-        mHVM.clear()
-        mHVM.setClicks((payload.corners ?: return).map {
+        mHVM.setClicks((payload.corners!!).map {
             Offset(it.first, it.second)
         })
     }
@@ -80,7 +80,6 @@ class PictureDisplayViewModel(
 
     fun reset() {
         if (pictureQueue.isEmpty()) return
-        mHVM.clear()
         setPicture(pictureQueue[selectedPictureIndex.value])
     }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,6 +14,7 @@ koin-compose = "1.0.3"
 kotlinxSerializationJson = "1.6.2"
 material3 = "1.3.0"
 kotlin-android = "1.8.20"
+exifinterface = "1.3.7"
 
 [libraries]
 activity-compose = { module = "androidx.activity:activity-compose", version.ref = "activityCompose" }
@@ -36,6 +37,7 @@ ui-test-junit4 = { module = "androidx.compose.ui:ui-test-junit4", version.ref = 
 ui-test-manifest = { module = "androidx.compose.ui:ui-test-manifest", version.ref = "ui" }
 ui-tooling = { module = "androidx.compose.ui:ui-tooling", version.ref = "ui" }
 ui-tooling-preview = { module = "androidx.compose.ui:ui-tooling-preview", version.ref = "ui" }
+exifinterface = { group = "androidx.exifinterface", name = "exifinterface", version.ref = "exifinterface" }
 
 [plugins]
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }


### PR DESCRIPTION
### Android
- Fix images taking long because of coroutine blockage
- Fix detected points do not match the taken image because they are still from the preview
### Desktop
- Fix show detected points after reset
- Fix cropping not working until point moved
- Fix rotation not applying until point moved
- Optimizations