### PR TITLE
Feature/net/allow multiple network interfaces

### DIFF
--- a/common/src/main/kotlin/com/github/picture2pc/common/net/di/multicastModule.kt
+++ b/common/src/main/kotlin/com/github/picture2pc/common/net/di/multicastModule.kt
@@ -13,7 +13,7 @@ import java.net.InetSocketAddress
 val multicastModule = module {
     single(named("multicastCoroutineScope")) { CoroutineScope(Dispatchers.Default + SupervisorJob()) }
 
-    single { MulticastPayloadTransceiver(get(named("multicastCoroutineScope")), get()) }
+    single { MulticastPayloadTransceiver(get(named("multicastCoroutineScope"))) }
     factory {
         SimpleMulticastSocket(
             get(named("multicastCoroutineScope")),

--- a/common/src/main/kotlin/com/github/picture2pc/common/net/extentions/NetworkInterface.kt
+++ b/common/src/main/kotlin/com/github/picture2pc/common/net/extentions/NetworkInterface.kt
@@ -3,9 +3,9 @@ package com.github.picture2pc.common.net.extentions
 import java.net.Inet4Address
 import java.net.NetworkInterface
 
-fun getDefaultNetworkInterface(): NetworkInterface? {
+fun getDefaultNetworkInterfaces(): Sequence<NetworkInterface> {
     val possible = NetworkInterface.getNetworkInterfaces().asSequence().filter(::isPossible)
-    return possible.maxWithOrNull(compareBy { it.inetAddresses.asSequence().count() })
+    return possible
 }
 
 private fun isPossible(networkInterface: NetworkInterface): Boolean {

--- a/common/src/main/kotlin/com/github/picture2pc/common/net/networkpayloadtransceiver/impl/multicast/MulticastConstants.kt
+++ b/common/src/main/kotlin/com/github/picture2pc/common/net/networkpayloadtransceiver/impl/multicast/MulticastConstants.kt
@@ -6,6 +6,7 @@ object MulticastConstants {
     const val RETRY_DELAY = 2000L
     const val POLLING_TIMEOUT = 2000
     const val UPDATE_INTERFACE_DELAY = 2000L
+    const val SEND_TO_NEXT_TIMEOUT = 2000
     const val PACKET_SIZE = 1024
 }
 

--- a/common/src/main/kotlin/com/github/picture2pc/common/net/networkpayloadtransceiver/impl/multicast/MulticastConstants.kt
+++ b/common/src/main/kotlin/com/github/picture2pc/common/net/networkpayloadtransceiver/impl/multicast/MulticastConstants.kt
@@ -5,6 +5,7 @@ object MulticastConstants {
     const val PORT = 42851
     const val RETRY_DELAY = 2000L
     const val POLLING_TIMEOUT = 2000
+    const val UPDATE_INTERFACE_DELAY = 2000L
     const val PACKET_SIZE = 1024
 }
 

--- a/common/src/main/kotlin/com/github/picture2pc/common/net/networkpayloadtransceiver/impl/multicast/MulticastPayloadTransceiver.kt
+++ b/common/src/main/kotlin/com/github/picture2pc/common/net/networkpayloadtransceiver/impl/multicast/MulticastPayloadTransceiver.kt
@@ -4,12 +4,10 @@ package com.github.picture2pc.common.net.networkpayloadtransceiver.impl.multicas
 import com.github.picture2pc.common.net.data.payload.Payload
 import com.github.picture2pc.common.net.extentions.getDefaultNetworkInterfaces
 import com.github.picture2pc.common.net.networkpayloadtransceiver.NetworkPayloadTransceiver
-import com.sun.org.apache.xpath.internal.operations.Mult
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withTimeout
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.get
 import java.net.NetworkInterface

--- a/common/src/main/kotlin/com/github/picture2pc/common/net/networkpayloadtransceiver/impl/multicast/MulticastPayloadTransceiver.kt
+++ b/common/src/main/kotlin/com/github/picture2pc/common/net/networkpayloadtransceiver/impl/multicast/MulticastPayloadTransceiver.kt
@@ -53,7 +53,7 @@ class MulticastPayloadTransceiver(
     private suspend fun startSingleSocket(networkInterface: NetworkInterface){
         val multicastSocket: SimpleMulticastSocket = get()
         multicastSocket.start(networkInterface)
-        multicastSockets.put(networkInterface, multicastSocket)
+        multicastSockets[networkInterface] = multicastSocket
         scope.launch {
             while (isActive) {
                 if (!multicastSocket.isAvailable){

--- a/common/src/main/kotlin/com/github/picture2pc/common/net/networkpayloadtransceiver/impl/multicast/MulticastPayloadTransceiver.kt
+++ b/common/src/main/kotlin/com/github/picture2pc/common/net/networkpayloadtransceiver/impl/multicast/MulticastPayloadTransceiver.kt
@@ -2,51 +2,76 @@ package com.github.picture2pc.common.net.networkpayloadtransceiver.impl.multicas
 
 
 import com.github.picture2pc.common.net.data.payload.Payload
+import com.github.picture2pc.common.net.extentions.getDefaultNetworkInterfaces
 import com.github.picture2pc.common.net.networkpayloadtransceiver.NetworkPayloadTransceiver
+import com.sun.org.apache.xpath.internal.operations.Mult
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeout
 import org.koin.core.component.KoinComponent
+import org.koin.core.component.get
+import java.net.NetworkInterface
 
 class MulticastPayloadTransceiver(
     private val scope: CoroutineScope,
-    private val multicastSocket: SimpleMulticastSocket
 ) : KoinComponent, NetworkPayloadTransceiver() {
 
+    private val multicastSockets: MutableMap<NetworkInterface, SimpleMulticastSocket> = mutableMapOf()
 
     override val available: Boolean
-        get() = multicastSocket.isAvailable
+        get() = multicastSockets.values.any { it.isAvailable }
 
     override suspend fun start() {
-        while (kotlin.runCatching { multicastSocket.start() }.isFailure) {
-            delay(MulticastConstants.RETRY_DELAY)
-        }
+        updateMulticastSockets()
 
         scope.launch {
-            while (isActive) {
-                while (isActive) {
-                    try {
-                        withTimeout(MulticastConstants.RETRY_DELAY) {
-                            multicastSocket.start()
-                        }
-                    } catch (e: Exception) {
-                        delay(MulticastConstants.RETRY_DELAY)
-                        continue
-                    }
-                    break
-                }
-                while (isActive) {
-                    if (!multicastSocket.isAvailable)
-                        break
-                    receivedPayload(multicastSocket.receivePayload() ?: continue)
-                }
+            while (isActive){
+                updateMulticastSockets()
+                delay(MulticastConstants.UPDATE_INTERFACE_DELAY)
             }
         }
     }
 
+    private suspend fun updateMulticastSockets(){
+        while (kotlin.runCatching {
+                val interfaces = getDefaultNetworkInterfaces().toSet()
+                val newInterfaces = interfaces.minus(multicastSockets.keys)
+                val removeInterfaces = multicastSockets.keys.minus(interfaces)
+                println(multicastSockets)
+                newInterfaces.forEach {
+                    startSingleSocket(it)
+                }
+                removeInterfaces.forEach {
+                    stopSingleSocket(it)
+                }
+            }.isFailure) {
+            delay(MulticastConstants.RETRY_DELAY)
+        }
+    }
+
+    private suspend fun startSingleSocket(networkInterface: NetworkInterface){
+        val multicastSocket: SimpleMulticastSocket = get()
+        multicastSocket.start(networkInterface)
+        multicastSockets.put(networkInterface, multicastSocket)
+        scope.launch {
+            while (true) {
+                if (!multicastSocket.isAvailable){
+                    stopSingleSocket(networkInterface)
+                    return@launch
+                }
+                println(multicastSocket.receivePayload())
+                receivedPayload(multicastSocket.receivePayload() ?: continue)
+            }
+        }
+    }
+
+    private fun stopSingleSocket(networkInterface: NetworkInterface){
+        multicastSockets.remove(networkInterface)?.close()
+    }
+
     override suspend fun _sendPayload(payload: Payload): Boolean {
-        return multicastSocket.sendMessage(payload)
+        return multicastSockets.values.map{it.sendMessage(payload)}.any()
     }
 }

--- a/common/src/main/kotlin/com/github/picture2pc/common/net/networkpayloadtransceiver/impl/multicast/MulticastPayloadTransceiver.kt
+++ b/common/src/main/kotlin/com/github/picture2pc/common/net/networkpayloadtransceiver/impl/multicast/MulticastPayloadTransceiver.kt
@@ -8,6 +8,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeoutOrNull
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.get
 import java.net.NetworkInterface
@@ -54,13 +55,19 @@ class MulticastPayloadTransceiver(
         multicastSocket.start(networkInterface)
         multicastSockets.put(networkInterface, multicastSocket)
         scope.launch {
-            while (true) {
+            while (isActive) {
                 if (!multicastSocket.isAvailable){
                     stopSingleSocket(networkInterface)
                     return@launch
                 }
                 println(multicastSocket.receivePayload())
-                receivedPayload(multicastSocket.receivePayload() ?: continue)
+                val payload = multicastSocket.receivePayload() ?: continue
+                launch {
+                    withTimeoutOrNull(2000) {
+                        sendPayloadExcluding(payload, multicastSocket)
+                    }
+                }
+                receivedPayload(payload)
             }
         }
     }
@@ -69,7 +76,15 @@ class MulticastPayloadTransceiver(
         multicastSockets.remove(networkInterface)?.close()
     }
 
+    private suspend fun sendPayloadExcluding(
+        payload: Payload,
+        simpleMulticastSocket: SimpleMulticastSocket? = null
+    ): Boolean {
+        return multicastSockets.values.filter { it != simpleMulticastSocket }
+            .map { it.sendMessage(payload) }.any()
+    }
+
     override suspend fun _sendPayload(payload: Payload): Boolean {
-        return multicastSockets.values.map{it.sendMessage(payload)}.any()
+        return sendPayloadExcluding(payload)
     }
 }

--- a/common/src/main/kotlin/com/github/picture2pc/common/net/networkpayloadtransceiver/impl/multicast/MulticastPayloadTransceiver.kt
+++ b/common/src/main/kotlin/com/github/picture2pc/common/net/networkpayloadtransceiver/impl/multicast/MulticastPayloadTransceiver.kt
@@ -38,7 +38,6 @@ class MulticastPayloadTransceiver(
                 val interfaces = getDefaultNetworkInterfaces().toSet()
                 val newInterfaces = interfaces.minus(multicastSockets.keys)
                 val removeInterfaces = multicastSockets.keys.minus(interfaces)
-                println(multicastSockets)
                 newInterfaces.forEach {
                     startSingleSocket(it)
                 }
@@ -60,7 +59,6 @@ class MulticastPayloadTransceiver(
                     stopSingleSocket(networkInterface)
                     return@launch
                 }
-                println(multicastSocket.receivePayload())
                 val payload = multicastSocket.receivePayload() ?: continue
                 launch {
                     withTimeoutOrNull(2000) {

--- a/common/src/main/kotlin/com/github/picture2pc/common/net/networkpayloadtransceiver/impl/multicast/SimpleMulticastSocket.kt
+++ b/common/src/main/kotlin/com/github/picture2pc/common/net/networkpayloadtransceiver/impl/multicast/SimpleMulticastSocket.kt
@@ -7,9 +7,6 @@ import com.github.picture2pc.common.net.data.serialization.asByteArray
 import com.github.picture2pc.common.net.data.serialization.fromByteArray
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.sync.Mutex
-import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import java.io.IOException
 import java.net.DatagramPacket
@@ -72,9 +69,9 @@ class SimpleMulticastSocket(
             withContext(ioDispatcher) {
                 jvmMulticastSocket.receive(datagramPacket)
             }
-        } catch (e: SocketTimeoutException) {
+        } catch (_: SocketTimeoutException) {
             return null
-        } catch (e: IOException) {
+        } catch (_: IOException) {
             close()
             return null
         }

--- a/common/src/main/kotlin/com/github/picture2pc/common/net/networkpayloadtransceiver/impl/multicast/SimpleMulticastSocket.kt
+++ b/common/src/main/kotlin/com/github/picture2pc/common/net/networkpayloadtransceiver/impl/multicast/SimpleMulticastSocket.kt
@@ -5,7 +5,6 @@ import com.github.picture2pc.common.net.data.payload.PayloadInfo
 import com.github.picture2pc.common.net.data.peer.Peer
 import com.github.picture2pc.common.net.data.serialization.asByteArray
 import com.github.picture2pc.common.net.data.serialization.fromByteArray
-import com.github.picture2pc.common.net.extentions.getDefaultNetworkInterface
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
@@ -16,6 +15,7 @@ import java.io.IOException
 import java.net.DatagramPacket
 import java.net.InetSocketAddress
 import java.net.MulticastSocket
+import java.net.NetworkInterface
 import java.net.SocketTimeoutException
 
 
@@ -25,15 +25,15 @@ class SimpleMulticastSocket(
     private val inetSocketAddress: InetSocketAddress
 ) {
     private lateinit var jvmMulticastSocket: MulticastSocket
-    private var lock: Mutex = Mutex()
     // get network interface for local dns
 
-    suspend fun start() {
+    suspend fun start(networkInterface: NetworkInterface) {
         withContext(ioDispatcher) {
             jvmMulticastSocket = MulticastSocket(inetSocketAddress.port)
             jvmMulticastSocket.soTimeout = MulticastConstants.POLLING_TIMEOUT
-            jvmMulticastSocket.networkInterface = getDefaultNetworkInterface()
-            jvmMulticastSocket.joinGroup(inetSocketAddress, null)
+            jvmMulticastSocket.reuseAddress = true
+            jvmMulticastSocket.networkInterface = networkInterface
+            jvmMulticastSocket.joinGroup(inetSocketAddress, networkInterface)
         }
     }
 
@@ -59,7 +59,7 @@ class SimpleMulticastSocket(
 
     }
 
-    private fun close() {
+    fun close() {
         jvmMulticastSocket.close()
     }
 
@@ -73,19 +73,6 @@ class SimpleMulticastSocket(
                 jvmMulticastSocket.receive(datagramPacket)
             }
         } catch (e: SocketTimeoutException) {
-            scope.launch(ioDispatcher) {
-                if (lock.isLocked)
-                    return@launch
-                lock.withLock {
-                kotlin.runCatching {
-                    val new = getDefaultNetworkInterface()
-                    if (new != jvmMulticastSocket.networkInterface) {
-                        jvmMulticastSocket.networkInterface = new
-                        jvmMulticastSocket.joinGroup(inetSocketAddress, null)
-                    }
-                }
-                }
-            }
             return null
         } catch (e: IOException) {
             close()

--- a/common/src/main/kotlin/com/github/picture2pc/common/net/networkpayloadtransceiver/impl/tcp/SimpleTcpServer.kt
+++ b/common/src/main/kotlin/com/github/picture2pc/common/net/networkpayloadtransceiver/impl/tcp/SimpleTcpServer.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -28,7 +29,6 @@ import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeout
 import org.koin.core.component.KoinComponent
 import java.net.InetSocketAddress
-import kotlin.collections.set
 
 class SimpleTcpServer(
     private val backgroundScope: CoroutineScope,
@@ -75,7 +75,7 @@ class SimpleTcpServer(
                 withTimeout(CONNECTION_TIMEOUT) {
                     jvmServerSocket.accept()
                 }
-            } catch (e: Exception) {
+            } catch (_: Exception) {
                 return false
             }
         val client = SimpleTcpClient(backgroundScope + Job(), ioDispatcher, jvmSocket)
@@ -109,10 +109,7 @@ class SimpleTcpServer(
                     it.sendMessage(data)
                 }
             }
-            jobs.forEach {
-                if (!it.await()) return false
-            }
-            return true
+            return jobs.awaitAll().all { it }
         }
         println("Sending: $payload")
         val client = peerToClientMap.getOrDefault(payload.targetPeer, null) ?: return false

--- a/desktop/src/main/kotlin/com/github/picture2pc/desktop/main.kt
+++ b/desktop/src/main/kotlin/com/github/picture2pc/desktop/main.kt
@@ -6,7 +6,6 @@ import kotlinx.coroutines.InternalCoroutinesApi
 import kotlinx.coroutines.newCoroutineContext
 import org.koin.core.context.startKoin
 import org.koin.dsl.module
-import org.opencv.core.Core
 
 @OptIn(InternalCoroutinesApi::class)
 fun main() {
@@ -16,7 +15,7 @@ fun main() {
         factory { Dispatchers.IO.newCoroutineContext(Dispatchers.IO) }
     }
 
-    System.loadLibrary(Core.NATIVE_LIBRARY_NAME)
+    //System.loadLibrary(Core.NATIVE_LIBRARY_NAME)
 
     startKoin {
         allowOverride(false)


### PR DESCRIPTION
This pull request refactors the multicast networking implementation to support multiple network interfaces, improves socket lifecycle management, and simplifies error handling across the codebase. The changes also introduce new constants for better configurability and update related utility functions.

### Multicast networking improvements

* Refactored `MulticastPayloadTransceiver` to manage multiple `SimpleMulticastSocket` instances, one per network interface, allowing simultaneous multicast communication across all available interfaces. The transceiver now dynamically adds or removes sockets as network interfaces change. (`common/src/main/kotlin/com/github/picture2pc/common/net/networkpayloadtransceiver/impl/multicast/MulticastPayloadTransceiver.kt`)
* Updated `SimpleMulticastSocket` to accept a specific `NetworkInterface` when starting, and removed the logic for automatically switching interfaces on timeout. Socket closure is now exposed through a public method for better lifecycle management. (`common/src/main/kotlin/com/github/picture2pc/common/net/networkpayloadtransceiver/impl/multicast/SimpleMulticastSocket.kt`) [[1]](diffhunk://#diff-7b65d00c8ba1b5afe1e0af000e6ac27cd692a7d600c2e9189abf056ded7f55d3L28-R33) [[2]](diffhunk://#diff-7b65d00c8ba1b5afe1e0af000e6ac27cd692a7d600c2e9189abf056ded7f55d3L62-R59) [[3]](diffhunk://#diff-7b65d00c8ba1b5afe1e0af000e6ac27cd692a7d600c2e9189abf056ded7f55d3L75-R74)

### Utility and configuration changes

* Changed the network interface utility function to return all possible interfaces as a sequence instead of a single default, supporting the new multi-interface logic. (`common/src/main/kotlin/com/github/picture2pc/common/net/extentions/NetworkInterface.kt`)
* Added new constants to `MulticastConstants` for interface update delay and send timeout, improving configurability for multicast operations. (`common/src/main/kotlin/com/github/picture2pc/common/net/networkpayloadtransceiver/impl/multicast/MulticastConstants.kt`)

### Dependency injection updates

* Updated the DI module to construct `MulticastPayloadTransceiver` without directly injecting a socket, reflecting the new socket management strategy. (`common/src/main/kotlin/com/github/picture2pc/common/net/di/multicastModule.kt`)

### Error handling and code simplification

* Simplified error handling in both multicast and TCP server implementations by catching exceptions with `_` and using more concise coroutine utilities (`awaitAll` instead of manual looping). (`common/src/main/kotlin/com/github/picture2pc/common/net/networkpayloadtransceiver/impl/tcp/SimpleTcpServer.kt`) [[1]](diffhunk://#diff-8c37494dcd73942d380f87bcf8274b5fe07aab16950eb6c026b23db4be09a25fR13) [[2]](diffhunk://#diff-8c37494dcd73942d380f87bcf8274b5fe07aab16950eb6c026b23db4be09a25fL78-R78) [[3]](diffhunk://#diff-8c37494dcd73942d380f87bcf8274b5fe07aab16950eb6c026b23db4be09a25fL112-R112)

These changes collectively make the networking layer more robust, flexible, and maintainable.